### PR TITLE
Projects router

### DIFF
--- a/src/api/v1/projects/createNewProject.ts
+++ b/src/api/v1/projects/createNewProject.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction } from "express";
+import { processToken } from "../token-utils";
+import { Project } from "../../../sequelize/models/project.model";
+import { respond, IMoiraResponse } from "../../../utils";
+import MoiraError from "../../../exceptions/MoiraError";
+import { HttpStatus } from "../../../HttpStatus";
+
+export default async function createNewProject(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const userInfo = processToken(req, next);
+  const { name, description } = req.body;
+  try {
+    const project = new Project({
+      name,
+      description,
+      creatorId: userInfo.id,
+      creator: userInfo.username,
+    });
+    const savedProject = await project.save();
+    respond(res, {
+      success: true,
+      status: 201,
+      data: savedProject,
+    } as IMoiraResponse);
+  } catch (e) {
+    next(
+      new MoiraError({
+        title: "Internal Server Error",
+        detail: "Sorry - something went wrong on our end",
+        httpStatus: HttpStatus.INTERNAL_SERVER_ERROR,
+      })
+    );
+  }
+}

--- a/src/api/v1/projects/deleteProject.ts
+++ b/src/api/v1/projects/deleteProject.ts
@@ -1,0 +1,38 @@
+import { Request, Response, NextFunction } from "express";
+import { Project } from "../../../sequelize/models/project.model";
+import { respond, IMoiraResponse } from "../../../utils";
+import MoiraError from "../../../exceptions/MoiraError";
+import { HttpStatus } from "../../../HttpStatus";
+
+export default async function deleteProject(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const { id } = req.params;
+  try {
+    const project = await Project.findOne({ where: { id } });
+    if (project) {
+      await project.destroy();
+      respond(res, {
+        success: true,
+        status: HttpStatus.OK,
+        data: project,
+      } as IMoiraResponse);
+    } else {
+      next(new MoiraError({
+        title: "Project Not Found",
+        detail: `Could not find the project with id ${id}`,
+        httpStatus: HttpStatus.NOT_FOUND,
+      }));
+    }
+  } catch (e) {
+    next(
+      new MoiraError({
+        title: "Internal Server Error",
+        detail: "Sorry - something went wrong on our end",
+        httpStatus: HttpStatus.INTERNAL_SERVER_ERROR,
+      })
+    );
+  }
+}

--- a/src/api/v1/projects/getAllProjects.ts
+++ b/src/api/v1/projects/getAllProjects.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from "express";
+import { processToken } from "../token-utils";
+import { Project } from "../../../sequelize/models/project.model";
+import { respond, IMoiraResponse } from "../../../utils";
+import MoiraError from "../../../exceptions/MoiraError";
+import { HttpStatus } from "../../../HttpStatus";
+
+export default async function getAllProjects(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const userInfo = processToken(req, next);
+
+  try {
+    const projects = await Project.findAll({ where: { creatorId: userInfo.id } });
+    respond(res, {
+      success: true,
+      status: HttpStatus.OK,
+      data: projects,
+    } as IMoiraResponse);
+  } catch (e) {
+    next(
+      new MoiraError({
+        title: "Internal Server Error",
+        detail: "Sorry - something went wrong on our end",
+        httpStatus: HttpStatus.INTERNAL_SERVER_ERROR,
+      })
+    );
+  }
+}

--- a/src/api/v1/projects/getProject.ts
+++ b/src/api/v1/projects/getProject.ts
@@ -1,0 +1,43 @@
+import { Request, Response, NextFunction } from "express";
+import { processToken } from "../token-utils";
+import { Project } from "../../../sequelize/models/project.model";
+import { respond, IMoiraResponse } from "../../../utils";
+import MoiraError from "../../../exceptions/MoiraError";
+import { HttpStatus } from "../../../HttpStatus";
+
+export default async function getProject(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const userInfo = processToken(req, next);
+  const { id } = req.params;
+
+  try {
+    const project = await Project.findOne({ where: { id } });
+
+    if (project && project.creatorId === userInfo.id) {
+      respond(res, {
+        success: true,
+        status: HttpStatus.OK,
+        data: project,
+      } as IMoiraResponse);
+    } else {
+      next(
+        new MoiraError({
+          title: "Project Not Found",
+          detail: `Project not found with id ${id}`,
+          httpStatus: HttpStatus.NOT_FOUND,
+        })
+      );
+    }
+  } catch (e) {
+    next(
+      new MoiraError({
+        title: "Internal Server Error",
+        detail: "Sorry - something went wrong on our end",
+        httpStatus: HttpStatus.INTERNAL_SERVER_ERROR,
+      })
+    );
+  }
+}

--- a/src/api/v1/projects/index.ts
+++ b/src/api/v1/projects/index.ts
@@ -7,10 +7,13 @@ import createNewProject from "./createNewProject";
 import deleteProject from "./deleteProject";
 import updateProjectSchema from "../validation-schemas/updateProject.schema";
 import updateProject from "./updateProject";
+import getProject from "./getProject";
 
 const projectsRouter = express.Router();
 
 projectsRouter.get("/", authorizeRequest(), getAllProjects);
+
+projectsRouter.get("/:id", authorizeRequest(), getProject);
 
 projectsRouter.post(
   "/",

--- a/src/api/v1/projects/index.ts
+++ b/src/api/v1/projects/index.ts
@@ -5,6 +5,8 @@ import newProjectSchema from "../validation-schemas/newProject.schema";
 import getAllProjects from "./getAllProjects";
 import createNewProject from "./createNewProject";
 import deleteProject from "./deleteProject";
+import updateProjectSchema from "../validation-schemas/updateProject.schema";
+import updateProject from "./updateProject";
 
 const projectsRouter = express.Router();
 
@@ -15,6 +17,13 @@ projectsRouter.post(
   authorizeRequest(),
   makeSchemaValidator(newProjectSchema),
   createNewProject
+);
+
+projectsRouter.put(
+  "/:id",
+  authorizeRequest(),
+  makeSchemaValidator(updateProjectSchema),
+  updateProject
 );
 
 projectsRouter.delete("/:id", authorizeRequest(), deleteProject);

--- a/src/api/v1/projects/index.ts
+++ b/src/api/v1/projects/index.ts
@@ -1,70 +1,19 @@
-import express, { NextFunction, Request, Response } from "express";
+import express from "express";
 import authorizeRequest from "../authorizeRequest";
-import { processToken } from "../token-utils";
-import { Project } from "../../../sequelize/models/project.model";
-import { IMoiraResponse, respond } from "../../../utils";
-import { HttpStatus } from "../../../HttpStatus";
-import MoiraError from "../../../exceptions/MoiraError";
 import makeSchemaValidator from "../../../middleware/makeSchemaValidator";
 import newProjectSchema from "../validation-schemas/newProject.schema";
+import getAllProjects from "./getAllProjects";
+import createNewProject from "./createNewProject";
 
 const projectsRouter = express.Router();
 
-projectsRouter.get(
-  "/",
-  authorizeRequest(),
-  async (req: Request, res: Response, next: NextFunction) => {
-    const userInfo = processToken(req, next);
-
-    try {
-      const projects = Project.findAll({ where: { id: userInfo.id } });
-      respond(res, {
-        success: true,
-        status: HttpStatus.OK,
-        data: projects,
-      } as IMoiraResponse);
-    } catch (e) {
-      next(
-        new MoiraError({
-          title: "Internal Server Error",
-          detail: "Sorry - something went wrong on our end",
-          httpStatus: HttpStatus.INTERNAL_SERVER_ERROR,
-        })
-      );
-    }
-  }
-);
+projectsRouter.get("/", authorizeRequest(), getAllProjects);
 
 projectsRouter.post(
   "/",
   authorizeRequest(),
   makeSchemaValidator(newProjectSchema),
-  async (req: Request, res: Response, next: NextFunction) => {
-    const userInfo = processToken(req, next);
-    const { name, description } = req.body;
-    try {
-      const project = new Project({
-        name,
-        description,
-        creatorId: userInfo.id,
-        creator: userInfo.username,
-      });
-      const savedProject = await project.save();
-      respond(res, {
-        success: true,
-        status: 201,
-        data: savedProject,
-      } as IMoiraResponse);
-    } catch (e) {
-      next(
-        new MoiraError({
-          title: "Internal Server Error",
-          detail: "Sorry - something went wrong on our end",
-          httpStatus: HttpStatus.INTERNAL_SERVER_ERROR,
-        })
-      );
-    }
-  }
+  createNewProject
 );
 
 export default projectsRouter;

--- a/src/api/v1/projects/index.ts
+++ b/src/api/v1/projects/index.ts
@@ -4,6 +4,7 @@ import makeSchemaValidator from "../../../middleware/makeSchemaValidator";
 import newProjectSchema from "../validation-schemas/newProject.schema";
 import getAllProjects from "./getAllProjects";
 import createNewProject from "./createNewProject";
+import deleteProject from "./deleteProject";
 
 const projectsRouter = express.Router();
 
@@ -15,5 +16,7 @@ projectsRouter.post(
   makeSchemaValidator(newProjectSchema),
   createNewProject
 );
+
+projectsRouter.delete("/:id", authorizeRequest(), deleteProject);
 
 export default projectsRouter;

--- a/src/api/v1/projects/updateProject.ts
+++ b/src/api/v1/projects/updateProject.ts
@@ -1,0 +1,44 @@
+import { Request, Response, NextFunction } from "express";
+import { processToken } from "../token-utils";
+import { Project } from "../../../sequelize/models/project.model";
+import { respond, IMoiraResponse } from "../../../utils";
+import MoiraError from "../../../exceptions/MoiraError";
+import { HttpStatus } from "../../../HttpStatus";
+
+export default async function updateProject(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const userInfo = processToken(req, next);
+  const { id } = req.params;
+
+  try {
+    const project = await Project.findOne({ where: { id } });
+
+    if (project && project.creatorId === userInfo.id) {
+      const updatedProject = await project.update(req.body);
+      respond(res, {
+        success: true,
+        status: HttpStatus.OK,
+        data: updatedProject,
+      } as IMoiraResponse);
+    } else {
+      next(
+        new MoiraError({
+          title: "Project Not Found",
+          detail: `Could not find the project with id ${id}`,
+          httpStatus: HttpStatus.NOT_FOUND,
+        })
+      );
+    }
+  } catch (e) {
+    next(
+      new MoiraError({
+        title: "Internal Server Error",
+        detail: "Sorry - something went wrong on our end",
+        httpStatus: HttpStatus.INTERNAL_SERVER_ERROR,
+      })
+    );
+  }
+}

--- a/src/api/v1/validation-schemas/updateProject.schema.ts
+++ b/src/api/v1/validation-schemas/updateProject.schema.ts
@@ -1,0 +1,8 @@
+import Joi from "joi";
+
+const updateProjectSchema = Joi.object({
+  name: Joi.string(),
+  description: Joi.string(),
+});
+
+export default updateProjectSchema;


### PR DESCRIPTION
Refactor existing projects endpoints into separate files. Fix bug in getting all projects logic. Implement `getProject`, `deleteProject`, and `updateProject`. Ensure that only the creator of a project can view that project.